### PR TITLE
Removes deprecated MessageType class and related Identity class usages

### DIFF
--- a/src/main/java/com/playmonumenta/networkchat/PlayerChatHistory.java
+++ b/src/main/java/com/playmonumenta/networkchat/PlayerChatHistory.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -144,7 +143,7 @@ public class PlayerChatHistory {
 	public void clearChat() {
 		mUnseenMessages.clear();
 		mSeenMessages.clear();
-		mSeenMessages.add(Message.createRawMessage(MessageType.SYSTEM, null, null, Component.text("Chat has been cleared.", NamedTextColor.RED, TextDecoration.BOLD)));
+		mSeenMessages.add(Message.createRawMessage(null, null, Component.text("Chat has been cleared.", NamedTextColor.RED, TextDecoration.BOLD)));
 		refreshChat();
 	}
 

--- a/src/main/java/com/playmonumenta/networkchat/PlayerStateManager.java
+++ b/src/main/java/com/playmonumenta/networkchat/PlayerStateManager.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nullable;
-import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
@@ -105,13 +104,7 @@ public class PlayerStateManager implements Listener {
 						}
 					}
 
-					MessageType messageType;
-					if (chatType.equals(ChatType.CHAT)) {
-						messageType = MessageType.CHAT;
-					} else {
-						messageType = MessageType.SYSTEM;
-					}
-					Message message = Message.createRawMessage(messageType, sender, null, messageComponent);
+					Message message = Message.createRawMessage(sender, null, messageComponent);
 
 					PlayerState playerState = mPlayerStates.get(event.getPlayer().getUniqueId());
 					if (playerState != null) {

--- a/src/main/java/com/playmonumenta/networkchat/channel/ChannelAnnouncement.java
+++ b/src/main/java/com/playmonumenta/networkchat/channel/ChannelAnnouncement.java
@@ -24,8 +24,6 @@ import java.util.Map;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import me.clip.placeholderapi.PlaceholderAPI;
-import net.kyori.adventure.audience.MessageType;
-import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
@@ -213,7 +211,7 @@ public class ChannelAnnouncement extends Channel implements ChannelAutoJoin, Cha
 
 		messageText = PlaceholderAPI.setPlaceholders(null, messageText);
 
-		@Nullable Message message = Message.createMessage(this, MessageType.SYSTEM, sender, null, messageText);
+		@Nullable Message message = Message.createMessage(this, sender, null, messageText);
 		if (message == null) {
 			return;
 		}
@@ -261,7 +259,7 @@ public class ChannelAnnouncement extends Channel implements ChannelAutoJoin, Cha
 
 	@Override
 	public void showMessage(CommandSender recipient, Message message) {
-		recipient.sendMessage(Identity.nil(), shownMessage(recipient, message), message.getMessageType());
+		recipient.sendMessage(shownMessage(recipient, message));
 		if (recipient instanceof Player player) {
 			@Nullable PlayerState playerState = PlayerStateManager.getPlayerState(player);
 			if (playerState == null) {

--- a/src/main/java/com/playmonumenta/networkchat/channel/ChannelGlobal.java
+++ b/src/main/java/com/playmonumenta/networkchat/channel/ChannelGlobal.java
@@ -23,7 +23,6 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 import javax.annotation.Nullable;
-import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
@@ -206,7 +205,7 @@ public class ChannelGlobal extends Channel implements ChannelAutoJoin, ChannelPe
 			throw notListeningEx;
 		}
 
-		@Nullable Message message = Message.createMessage(this, MessageType.CHAT, sender, null, messageText);
+		@Nullable Message message = Message.createMessage(this, sender, null, messageText);
 		if (message == null) {
 			return;
 		}
@@ -257,7 +256,7 @@ public class ChannelGlobal extends Channel implements ChannelAutoJoin, ChannelPe
 	@Override
 	public void showMessage(CommandSender recipient, Message message) {
 		UUID senderUuid = message.getSenderId();
-		recipient.sendMessage(message.getSenderIdentity(), shownMessage(recipient, message), message.getMessageType());
+		recipient.sendMessage(shownMessage(recipient, message));
 		if (recipient instanceof Player player && !player.getUniqueId().equals(senderUuid)) {
 			@Nullable PlayerState playerState = PlayerStateManager.getPlayerState(player);
 			if (playerState == null) {

--- a/src/main/java/com/playmonumenta/networkchat/channel/ChannelLocal.java
+++ b/src/main/java/com/playmonumenta/networkchat/channel/ChannelLocal.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import javax.annotation.Nullable;
-import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
@@ -213,7 +212,7 @@ public class ChannelLocal extends Channel implements ChannelAutoJoin, ChannelPer
 		JsonObject extraData = new JsonObject();
 		extraData.addProperty("fromShard", NetworkChatPlugin.getShardName());
 
-		@Nullable Message message = Message.createMessage(this, MessageType.CHAT, sender, extraData, messageText);
+		@Nullable Message message = Message.createMessage(this, sender, extraData, messageText);
 		if (message == null) {
 			return;
 		}
@@ -283,7 +282,7 @@ public class ChannelLocal extends Channel implements ChannelAutoJoin, ChannelPer
 	@Override
 	public void showMessage(CommandSender recipient, Message message) {
 		UUID senderUuid = message.getSenderId();
-		recipient.sendMessage(message.getSenderIdentity(), shownMessage(recipient, message), message.getMessageType());
+		recipient.sendMessage(shownMessage(recipient, message));
 		if (recipient instanceof Player player && !player.getUniqueId().equals(senderUuid)) {
 			@Nullable PlayerState playerState = PlayerStateManager.getPlayerState(player);
 			if (playerState == null) {

--- a/src/main/java/com/playmonumenta/networkchat/channel/ChannelParty.java
+++ b/src/main/java/com/playmonumenta/networkchat/channel/ChannelParty.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 import javax.annotation.Nullable;
-import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
@@ -296,7 +295,7 @@ public class ChannelParty extends Channel implements ChannelInviteOnly {
 			throw notListeningEx;
 		}
 
-		@Nullable Message message = Message.createMessage(this, MessageType.CHAT, sender, null, messageText);
+		@Nullable Message message = Message.createMessage(this, sender, null, messageText);
 		if (message == null) {
 			return;
 		}
@@ -347,7 +346,7 @@ public class ChannelParty extends Channel implements ChannelInviteOnly {
 	@Override
 	public void showMessage(CommandSender recipient, Message message) {
 		UUID senderUuid = message.getSenderId();
-		recipient.sendMessage(message.getSenderIdentity(), shownMessage(recipient, message), message.getMessageType());
+		recipient.sendMessage(shownMessage(recipient, message));
 		if (recipient instanceof Player player && !player.getUniqueId().equals(senderUuid)) {
 			@Nullable PlayerState playerState = PlayerStateManager.getPlayerState(player);
 			if (playerState == null) {

--- a/src/main/java/com/playmonumenta/networkchat/channel/ChannelTeam.java
+++ b/src/main/java/com/playmonumenta/networkchat/channel/ChannelTeam.java
@@ -19,7 +19,6 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 import javax.annotation.Nullable;
-import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
@@ -270,7 +269,7 @@ public class ChannelTeam extends Channel {
 		JsonObject extraData = new JsonObject();
 		extraData.addProperty("team", mTeamName);
 
-		@Nullable Message message = Message.createMessage(this, MessageType.CHAT, sender, extraData, messageText);
+		@Nullable Message message = Message.createMessage(this, sender, extraData, messageText);
 		if (message == null) {
 			return;
 		}
@@ -374,7 +373,7 @@ public class ChannelTeam extends Channel {
 	@Override
 	public void showMessage(CommandSender recipient, Message message) {
 		UUID senderUuid = message.getSenderId();
-		recipient.sendMessage(message.getSenderIdentity(), shownMessage(recipient, message), message.getMessageType());
+		recipient.sendMessage(shownMessage(recipient, message));
 		if (recipient instanceof Player player && !player.getUniqueId().equals(senderUuid)) {
 			@Nullable PlayerState playerState = PlayerStateManager.getPlayerState(player);
 			if (playerState == null) {

--- a/src/main/java/com/playmonumenta/networkchat/channel/ChannelWhisper.java
+++ b/src/main/java/com/playmonumenta/networkchat/channel/ChannelWhisper.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 import javax.annotation.Nullable;
-import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
@@ -431,7 +430,7 @@ public class ChannelWhisper extends Channel implements ChannelInviteOnly {
 		JsonObject extraData = new JsonObject();
 		extraData.addProperty("receiver", receiverId.toString());
 
-		@Nullable Message message = Message.createMessage(this, MessageType.CHAT, sender, extraData, messageText);
+		@Nullable Message message = Message.createMessage(this, sender, extraData, messageText);
 		if (message == null) {
 			return;
 		}
@@ -522,7 +521,7 @@ public class ChannelWhisper extends Channel implements ChannelInviteOnly {
 	@Override
 	public void showMessage(CommandSender recipient, Message message) {
 		UUID senderUuid = message.getSenderId();
-		recipient.sendMessage(message.getSenderIdentity(), shownMessage(recipient, message), message.getMessageType());
+		recipient.sendMessage(shownMessage(recipient, message));
 		if (recipient instanceof Player player && !player.getUniqueId().equals(senderUuid)) {
 			@Nullable PlayerState playerState = PlayerStateManager.getPlayerState(player);
 			if (playerState == null) {

--- a/src/main/java/com/playmonumenta/networkchat/channel/ChannelWorld.java
+++ b/src/main/java/com/playmonumenta/networkchat/channel/ChannelWorld.java
@@ -27,7 +27,6 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 import javax.annotation.Nullable;
-import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
@@ -229,7 +228,7 @@ public class ChannelWorld extends Channel implements ChannelAutoJoin, ChannelPer
 		extraData.addProperty("fromShard", NetworkChatPlugin.getShardName());
 		extraData.addProperty("fromWorld", world.getName());
 
-		@Nullable Message message = Message.createMessage(this, MessageType.CHAT, sender, extraData, messageText);
+		@Nullable Message message = Message.createMessage(this, sender, extraData, messageText);
 		if (message == null) {
 			return;
 		}
@@ -316,7 +315,7 @@ public class ChannelWorld extends Channel implements ChannelAutoJoin, ChannelPer
 	@Override
 	public void showMessage(CommandSender recipient, Message message) {
 		UUID senderUuid = message.getSenderId();
-		recipient.sendMessage(message.getSenderIdentity(), shownMessage(recipient, message), message.getMessageType());
+		recipient.sendMessage(shownMessage(recipient, message));
 		if (recipient instanceof Player player && !player.getUniqueId().equals(senderUuid)) {
 			@Nullable PlayerState playerState = PlayerStateManager.getPlayerState(player);
 			if (playerState == null) {


### PR DESCRIPTION
This is due to Mojang dropping support for unsigned messages, which means either losing custom chat formatting, or not supporting vanilla info about who sent a given message. There is no other solution if I wish to support NetworkChat in future versions.