### PR TITLE
add permissions to `/chat player refresh`

### DIFF
--- a/src/main/java/com/playmonumenta/networkchat/RemotePlayerDiff.java
+++ b/src/main/java/com/playmonumenta/networkchat/RemotePlayerDiff.java
@@ -136,7 +136,7 @@ public class RemotePlayerDiff {
 		}
 	}
 
-	public static final int TIME_LIMIT_TICKS = 200;
+	public static final int TIME_LIMIT_TICKS = 100;
 
 	private static final List<DiffDeadline> mUpcomingDeadlines = new ArrayList<>();
 	private static final Map<UUID, DiffDeadline> mDeadlinesByPlayer = new HashMap<>();

--- a/src/main/java/com/playmonumenta/networkchat/commands/chat/player/ChatPlayerRefreshCommand.java
+++ b/src/main/java/com/playmonumenta/networkchat/commands/chat/player/ChatPlayerRefreshCommand.java
@@ -17,6 +17,7 @@ public class ChatPlayerRefreshCommand {
 		ChatCommand.getBaseCommand()
 			.withArguments(new LiteralArgument("player"))
 			.withArguments(new LiteralArgument("refresh"))
+			.withPermission("networkchat.player.refresh")
 			.executesNative((sender, args) -> {
 				CommandSender callee = CommandUtils.getCallee(sender);
 				if (!(callee instanceof Player target)) {
@@ -33,6 +34,7 @@ public class ChatPlayerRefreshCommand {
 			.withArguments(new LiteralArgument("player"))
 			.withArguments(new LiteralArgument("refresh"))
 			.withArguments(playersArg)
+			.withPermission("networkchat.player.refresh")
 			.executesNative((sender, args) -> {
 				@SuppressWarnings("unchecked")
 				Collection<Player> players = args.getByArgument(playersArg);


### PR DESCRIPTION
- reduce time limit ticks to 5 seconds for RPM testing